### PR TITLE
snow_monkey_forms/auto_reply_mailer/args フックの追加

### DIFF
--- a/App/Model/AutoReplyMailer.php
+++ b/App/Model/AutoReplyMailer.php
@@ -118,17 +118,24 @@ class AutoReplyMailer {
 	 * @return boolean
 	 */
 	protected function _process_sending( MailParser $mail_parser ) {
-		$mailer = new Mailer(
-			[
-				'to'          => $mail_parser->parse( $this->setting->get( 'auto_reply_email_to' ) ),
-				'subject'     => $mail_parser->parse( $this->setting->get( 'auto_reply_email_subject' ) ),
-				'body'        => $mail_parser->parse( $this->setting->get( 'auto_reply_email_body' ) ),
-				'attachments' => $mail_parser->get_attachments( $this->setting->get( 'auto_reply_email_body' ) ),
-				'from'        => $this->setting->get( 'auto_reply_email_from' ),
-				'sender'      => $this->setting->get( 'auto_reply_email_sender' ),
-				'headers'     => $this->_get_headers(),
-			]
+		$args = [
+			'to'          => $mail_parser->parse( $this->setting->get( 'auto_reply_email_to' ) ),
+			'subject'     => $mail_parser->parse( $this->setting->get( 'auto_reply_email_subject' ) ),
+			'body'        => $mail_parser->parse( $this->setting->get( 'auto_reply_email_body' ) ),
+			'attachments' => $mail_parser->get_attachments( $this->setting->get( 'auto_reply_email_body' ) ),
+			'from'        => $this->setting->get( 'auto_reply_email_from' ),
+			'sender'      => $this->setting->get( 'auto_reply_email_sender' ),
+			'headers'     => $this->_get_headers(),
+		];
+
+		$args = apply_filters(
+			'snow_monkey_forms/auto_reply_mailer/args',
+			$args,
+			$this->responser,
+			$this->setting
 		);
+
+		$mailer = new Mailer( $args );
 
 		return $mailer->send();
 	}


### PR DESCRIPTION
auto_reply_mailer 側には $args を変更するフックが無かったので、
snow_monkey_forms/auto_reply_mailer/args を snow_monkey_forms/administrator_mailer/args と同様の形で追加しました。
どうでしょ？