### PR TITLE
Fixed typo in class name.

### DIFF
--- a/App/Control/RadioButtons.php
+++ b/App/Control/RadioButtons.php
@@ -119,7 +119,7 @@ class RadioButtons extends Contract\Control {
 
 		$direction = $this->get_property( 'direction' );
 		$classes   = array();
-		$classes[] = 'smf-radio-cuttons-control';
+		$classes[] = 'smf-radio-buttons-control';
 		if ( $direction ) {
 			$classes[] = 'smf-radio-buttons-control--' . $direction;
 		}


### PR DESCRIPTION
RadioButtonsのclass名にタイポと思われる箇所がありましたので、そのclass名の修正です。
該当class名でCSS調整をされている方には影響がでると思います。