### PR TITLE
Checkboxes、RadioButtons、Selectにオプションを動的に追加/変更できるフィルターフックを追加

### DIFF
--- a/App/Control/Checkboxes.php
+++ b/App/Control/Checkboxes.php
@@ -89,10 +89,15 @@ class Checkboxes extends Contract\Control {
 	 * Initialized.
 	 */
 	protected function _init() {
+		/**
+		 * Set up a filter to which you can add any option
+		*/
+		$set_options = apply_filters('snow_monkey_forms/checkboxes/addchoise',$this->get_property( 'options' ),$this->get_property( 'name' ));
+
 		$this->set_property( 'name', $this->get_property( 'name' ) . '[]' );
 
 		$children = array();
-		foreach ( $this->get_property( 'options' ) as $option ) {
+		foreach ( $set_options as $option ) {
 			$value = array_keys( $option )[0];
 			$label = array_values( $option )[0];
 

--- a/App/Control/RadioButtons.php
+++ b/App/Control/RadioButtons.php
@@ -93,8 +93,13 @@ class RadioButtons extends Contract\Control {
 	 * Initialize.
 	 */
 	protected function _init() {
+		/**
+		 * Set up a filter to which you can add any option
+		*/
+		$set_options = apply_filters('snow_monkey_forms/radiobuttons/addchoise',$this->get_property( 'options' ),$this->get_property( 'name' ));
+
 		$children = array();
-		foreach ( $this->get_property( 'options' ) as $option ) {
+		foreach ( $set_options as $option ) {
 			$value = array_keys( $option )[0];
 			$label = array_values( $option )[0];
 

--- a/App/Control/Select.php
+++ b/App/Control/Select.php
@@ -64,8 +64,13 @@ class Select extends Contract\Control {
 	 * Initialize.
 	 */
 	protected function _init() {
+		/**
+		 * Set up a filter to which you can add any option
+		*/
+		$set_options = apply_filters('snow_monkey_forms/select/addchoise',$this->get_property( 'options' ),$this->get_attribute( 'name' ));
+
 		$children = array();
-		foreach ( $this->get_property( 'options' ) as $option ) {
+		foreach ( $set_options as $option ) {
 			$value = array_keys( $option )[0];
 			$label = array_values( $option )[0];
 


### PR DESCRIPTION
# Why
ラジオボタン、チェックボックス、セレクトボックスの選択項目を動的に変更できるようにしたい。
テキストやテキストエリアなどは'snow_monkey_forms/control/attributes'フィルターフックで後から値を動的に追加することができるが、CheckboxやSelect、RadioButtonはできないため。

# How
Checkboxes、RadioButtons、Selectにオプションを動的に追加/変更できる以下のフィルターフックを追加
snow_monkey_forms/select/addchoiseフィルターフック
snow_monkey_forms/radiobuttons/addchoiseフィルターフック
snow_monkey_forms/checkboxes/addchoiseフィルターフック


# Example of usage
カスタム投稿やカスタムタクソノミー、カスタムメタフィールドなどを選択肢に出すというようなことが可能になります。

NAME属性を"productName"にしたCheckBoxにoptionを追加する例
```php

add_filter('snow_monkey_forms/checkboxes/addchoise',

    function($options,$name) {

        if($name === "productName") {
           $add_products = [];
           $products = get_posts( array(
                'post_type' => 'product',
                 'post_per_page' => -1
            ));
            foreach($products as $product) {
                $add_products[] = array(
                    $product->post_title => array(
                        $product->post_title => $product->post_title
                    )
                );
            }
            
            return array_merge($options,$add_products);

        }

        return $options;
    },
    10,
    2
);
```